### PR TITLE
Make the stock broker implementation functional

### DIFF
--- a/charts/servicebroker/templates/broker-deployment.yaml
+++ b/charts/servicebroker/templates/broker-deployment.yaml
@@ -37,6 +37,9 @@ spec:
         - --tlsKey
         - "{{ .Values.tls.key }}"
         {{- end}}
+        - -v
+        - "5"
+        - -logtostderr
         ports:
         - containerPort: 8080
         readinessProbe:

--- a/cmd/servicebroker/main.go
+++ b/cmd/servicebroker/main.go
@@ -67,6 +67,8 @@ func runWithContext(ctx context.Context) error {
 
 	s := server.New(api)
 
+	glog.Infof("Starting broker!")
+
 	if options.TLSCert == "" && options.TLSKey == "" {
 		err = s.Run(ctx, addr)
 	} else {

--- a/examples/service-binding.yaml
+++ b/examples/service-binding.yaml
@@ -1,0 +1,8 @@
+apiVersion: servicecatalog.k8s.io/v1beta1
+kind: ServiceBinding
+metadata:
+  name: skeleton-service-binding
+  namespace: test-ns
+spec:
+  instanceRef:
+    name: skeleton-service-instance

--- a/examples/service-instance.yaml
+++ b/examples/service-instance.yaml
@@ -1,0 +1,11 @@
+apiVersion: servicecatalog.k8s.io/v1beta1
+kind: ServiceInstance
+metadata:
+  name: skeleton-service-instance
+  namespace: test-ns
+spec:
+  clusterServiceClassExternalName: skeleton-example-service
+  clusterServicePlanExternalName: default
+  parameters:
+    param-1: value-1
+    param-2: value-2


### PR DESCRIPTION
This PR:

- finishes implementing a minimally usable APISurface
- adds an example implementation that is similar to the ups-broker from service-catalog
